### PR TITLE
Fix plotly express subplot colors

### DIFF
--- a/plugins/plotly-express/src/PlotlyExpressChartModel.ts
+++ b/plugins/plotly-express/src/PlotlyExpressChartModel.ts
@@ -132,7 +132,7 @@ class PlotlyExpressChartModel extends ChartModel {
     /**
      * We will iterate over the traces with the following expectations
      * 1. Traces in the same subplot are contiguous in the data array
-     * 2. Traces of differet plot types indicate a new subplot
+     * 2. Traces of different plot types indicate a new subplot
      * 3. If the domain changes between traces, that indicates a new subplot
      * 4. Each subplot should start their colors from the beginning of the colorway
      */

--- a/plugins/plotly-express/src/PlotlyExpressChartModel.ts
+++ b/plugins/plotly-express/src/PlotlyExpressChartModel.ts
@@ -129,22 +129,68 @@ class PlotlyExpressChartModel extends ChartModel {
       return;
     }
 
-    // Remove colors set on traces by plotly on the server
+    /**
+     * We will iterate over the traces with the following expectations
+     * 1. Traces in the same subplot are contiguous in the data array
+     * 2. Traces of differet plot types indicate a new subplot
+     * 3. If the domain changes between traces, that indicates a new subplot
+     * 4. Each subplot should start their colors from the beginning of the colorway
+     */
+
+    let startSubplotIndex = 0; // Tracks what index the current subplot started at
+
     for (let i = 0; i < this.data.length; i += 1) {
-      const d = this.data[i];
-      const color = colorway[i % colorway.length];
+      const data = this.data[i];
+
+      // Check if we are starting a new subplot and should restart the color order
+      if (i > 0) {
+        const prevData = this.data[i - 1];
+        const isSamePlotType = data.type === prevData.type;
+        let isSameDomain = true;
+        if (isPlotData(data) && isPlotData(prevData)) {
+          isSameDomain = deepEqual(data.domain, prevData.domain);
+        }
+        if (!isSamePlotType || !isSameDomain) {
+          startSubplotIndex = i;
+        }
+      }
+
+      // The color index for the current subplot
+      const colorIndex = i - startSubplotIndex;
+
+      // Plotly just wraps back to the start of the colorway if numTraces > numColors
+      const themeColor = colorway[colorIndex % colorway.length];
 
       // If length is 0, plotlyColorway[NaN] is undefined and does not throw
-      const plotlyColor = plotlyColorway[i % plotlyColorway.length] ?? '';
+      const plotlyColor =
+        plotlyColorway[colorIndex % plotlyColorway.length] ?? '';
 
-      if (isPlotData(d)) {
-        const { marker, line } = d;
-        if (marker?.color === plotlyColor && color != null) {
-          marker.color = color;
+      // There are multiple datatypes in plotly and some don't contain marker or marker.color
+      if (
+        'marker' in data &&
+        data.marker != null &&
+        'color' in data.marker &&
+        typeof data.marker.color === 'string'
+      ) {
+        if (
+          data.marker.color.toUpperCase() === plotlyColor.toUpperCase() &&
+          themeColor != null
+        ) {
+          data.marker.color = themeColor;
         }
+      }
 
-        if (line?.color === plotlyColor && color != null) {
-          line.color = color;
+      if (
+        'line' in data &&
+        data.line != null &&
+        'color' in data.line &&
+        typeof data.line.color === 'string'
+      ) {
+        if (
+          data.line.color.toUpperCase() === plotlyColor.toUpperCase() &&
+          themeColor != null
+        ) {
+          data.line.color = themeColor;
         }
       }
     }


### PR DESCRIPTION
Depends on #20

Fixes the colors when using marginals or subplots in the plotly-express plugin

Example Python with subplots and marginals

```python
from deephaven import new_table
from deephaven.column import string_col, int_col, float_col
from deephaven import time_table
import deephaven.plot.express as dx
import random


source = time_table("00:00:01").update(formulas=[
    "Ints = (int)random.gauss(20, 5)",  
    "Ints2 = (int)random.gauss(30, 3)",
    "Ints3 = (int)random.gauss(20, 5)",  
    "Ints4 = (int)random.gauss(30, 3)",
    "Ints5 = (int)random.gauss(20, 5)",
    "size = max((int)random.gauss(10, 3), 1)",
    "size2 = max((int)random.gauss(10, 3), 1)",
    "size3 = max((int)random.gauss(10, 3), 1)",
    "size4 = max((int)random.gauss(10, 3), 1)",])  


source2 = time_table("00:00:01").update(formulas=["X = i%2 == 0 ? `Str11` : `Str2`", "Y = (int)random.randint(0, 100)"])

sources = time_table('00:00:01').update_view(["ID = i", "Parent = i == 0 ? NULL_INT : (int)(i / 4)"])

sun_fig = dx.sunburst(sources, names="ID", parents="Parent")

pie_fig = dx.pie(source2, names="X", values="Y")

scatter_fig = dx.scatter(source,
              y="Ints3",
              x=["Ints2", "Ints4", "Ints5", "Ints"],
              yaxis_sequence=[1,2,3],
              xaxis_sequence=[1,2],
              size=["size", "size2", "size3", "size4"]
)

scatter_marginal = dx.scatter(source,
                   y="Ints3",
                   x=["Ints2", "Ints4", "Ints5", "Ints"],
                   yaxis_sequence=[1,2,3],
                   xaxis_sequence=[1,2],
                   size=["size", "size2", "size3", "size4"],
                   marginal_x="violin"
)

sp2 = dx.make_subplots(
    grid=[
        [pie_fig, sun_fig],
        [scatter_fig, None]
    ],
    specs=[
        [{"l": 0.3}, {}],
        [{"colspan": 2}, None]
    ]
)
```