### PR TITLE
Retain any metadata that is passed in when opening panels from plugins

### DIFF
--- a/plugins/matplotlib/src/DashboardPlugin.tsx
+++ b/plugins/matplotlib/src/DashboardPlugin.tsx
@@ -23,11 +23,13 @@ export function DashboardPlugin({
     ({
       dragEvent,
       fetch,
+      metadata,
       panelId = shortid.generate(),
       widget,
     }: {
       dragEvent?: DragEvent;
       fetch: () => Promise<unknown>;
+      metadata?: Record<string, unknown>;
       panelId?: string;
       widget: VariableDefinition;
     }) => {
@@ -37,14 +39,18 @@ export function DashboardPlugin({
         return;
       }
       log.info('Panel opened of type', type);
-      const metadata = { id: widgetId, name, type };
       const config = {
         type: 'react-component' as const,
         component: MatPlotLibPanel.COMPONENT,
         props: {
           localDashboardId: id,
           id: panelId,
-          metadata,
+          metadata: {
+            ...(metadata ?? {}),
+            id: widgetId,
+            name,
+            type,
+          },
           fetch,
         },
         title: name,

--- a/plugins/matplotlib/src/DashboardPlugin.tsx
+++ b/plugins/matplotlib/src/DashboardPlugin.tsx
@@ -23,7 +23,7 @@ export function DashboardPlugin({
     ({
       dragEvent,
       fetch,
-      metadata,
+      metadata = {},
       panelId = shortid.generate(),
       widget,
     }: {
@@ -46,7 +46,7 @@ export function DashboardPlugin({
           localDashboardId: id,
           id: panelId,
           metadata: {
-            ...(metadata ?? {}),
+            ...metadata,
             id: widgetId,
             name,
             type,

--- a/plugins/plotly-express/src/DashboardPlugin.tsx
+++ b/plugins/plotly-express/src/DashboardPlugin.tsx
@@ -20,7 +20,7 @@ export function DashboardPlugin(
     async ({
       dragEvent,
       fetch,
-      metadata,
+      metadata = {},
       panelId = shortid.generate(),
       widget,
     }: {
@@ -42,7 +42,7 @@ export function DashboardPlugin(
           localDashboardId: id,
           id: panelId,
           metadata: {
-            ...(metadata ?? {}),
+            ...metadata,
             name: title,
             figure: title,
             type,

--- a/plugins/plotly-express/src/DashboardPlugin.tsx
+++ b/plugins/plotly-express/src/DashboardPlugin.tsx
@@ -20,11 +20,13 @@ export function DashboardPlugin(
     async ({
       dragEvent,
       fetch,
+      metadata,
       panelId = shortid.generate(),
       widget,
     }: {
       dragEvent?: DragEvent;
       fetch: () => Promise<PlotlyChartWidget>;
+      metadata?: Record<string, unknown>;
       panelId?: string;
       widget: VariableDefinition;
     }) => {
@@ -33,14 +35,18 @@ export function DashboardPlugin(
         return;
       }
 
-      const metadata = { name: title, figure: title, type };
       const config = {
         type: 'react-component' as const,
         component: 'PlotlyPanel',
         props: {
           localDashboardId: id,
           id: panelId,
-          metadata,
+          metadata: {
+            ...(metadata ?? {}),
+            name: title,
+            figure: title,
+            type,
+          },
           fetch,
         },
         title,

--- a/plugins/plotly/src/DashboardPlugin.tsx
+++ b/plugins/plotly/src/DashboardPlugin.tsx
@@ -26,11 +26,13 @@ export function DashboardPlugin(
     ({
       dragEvent,
       fetch,
+      metadata,
       panelId = shortid.generate(),
       widget,
     }: {
       dragEvent?: React.DragEvent;
       fetch: () => Promise<unknown>;
+      metadata?: Record<string, unknown>;
       panelId?: string;
       widget: VariableDefinition;
     }) => {
@@ -40,15 +42,18 @@ export function DashboardPlugin(
         return;
       }
 
-      const metadata = { name, figure: name, type };
-
       const config = {
         type: 'react-component' as const,
         component: PANEL_COMPONENT,
         props: {
           localDashboardId: id,
           id: panelId,
-          metadata,
+          metadata: {
+            ...(metadata ?? {}),
+            name,
+            figure: name,
+            type,
+          },
           fetch,
         },
         title: name,

--- a/plugins/plotly/src/DashboardPlugin.tsx
+++ b/plugins/plotly/src/DashboardPlugin.tsx
@@ -26,7 +26,7 @@ export function DashboardPlugin(
     ({
       dragEvent,
       fetch,
-      metadata,
+      metadata = {},
       panelId = shortid.generate(),
       widget,
     }: {
@@ -49,7 +49,7 @@ export function DashboardPlugin(
           localDashboardId: id,
           id: panelId,
           metadata: {
-            ...(metadata ?? {}),
+            ...metadata,
             name,
             figure: name,
             type,


### PR DESCRIPTION
- In DHE we pass in some metadata about the query which we need to reload the query
- Tested on https://bender-dnd-2.int.illumon.com:8123/iriside, ensured matplotlib panel could be opened from query and re-hydrated correctly
